### PR TITLE
fixed grabbing sessions from other day at creation

### DIFF
--- a/Smartscope/server/frontend/views.py
+++ b/Smartscope/server/frontend/views.py
@@ -21,6 +21,7 @@ import psutil
 import signal
 from django.utils.timezone import now
 from Smartscope.core.db_manipulations import viewer_only
+import datetime
 
 
 def signup(request):
@@ -148,7 +149,7 @@ class AutoScreenSetup(LoginRequiredMixin, TemplateView):
 
             if form_general.is_valid() and form_params.is_valid():
 
-                session, created = ScreeningSession.objects.get_or_create(**form_general.cleaned_data)
+                session, created = ScreeningSession.objects.get_or_create(**form_general.cleaned_data, date=datetime.today().strftime('%Y%m%d'))
                 if created:
                     print(f'{session} newly created')
                 else:


### PR DESCRIPTION
When users were creating session with an existing name, it would grab any session with the same name and append grids to it. Now the behavior still exists but will only append if a session name exists from the same day. This allows adding grids to session from the current day.

This will need to be improved later but should solve the main problem of appending grids from a session that is far in the past.