### PR TITLE
fixed error in preprocessing movies

### DIFF
--- a/Smartscope/core/preprocessing_pipelines.py
+++ b/Smartscope/core/preprocessing_pipelines.py
@@ -113,6 +113,7 @@ class SmartscopePreprocessingPipeline(PreprocessingPipeline):
                 continue
             data = get_CTFFIN4_data(movie.ctf)
             data['status'] = 'completed'
+            movie.read_image()
             data['shape_x'] = movie.shape_x
             data['shape_y'] = movie.shape_y
             logger.debug(f'Updating {movie.name}')


### PR DESCRIPTION
While trying to set the shape of the high_mag image coming from a movie, an error was fixed where it couldn't retrieve the value since the image was not opened