### PR TITLE
added a route to get the url for the report of a certain grid

### DIFF
--- a/Smartscope/server/api/viewsets.py
+++ b/Smartscope/server/api/viewsets.py
@@ -569,7 +569,13 @@ class AutoloaderGridViewSet(viewsets.ModelViewSet, GeneralActionsMixin, ExtraAct
             return Response(dict(out=out))
         except Exception as err:
             logger.error(f'Error tring to regrouping BIS and reselecting, {err}')
-            return Response(dict(success=False),status=rest_status.HTTP_500_INTERNAL_SERVER_ERROR)  
+            return Response(dict(success=False),status=rest_status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    @ action(detail=True, methods=['get'])
+    def get_report_url(self, request, *args, **kwargs):
+        obj:AutoloaderGrid = self.get_object()
+        url=  request.build_absolute_uri(reverse('browser') + f'?group={obj.session_id.group.pk}&session_id={obj.session_id.pk}&grid_id={obj.pk}')
+        return Response(url)
 
 
 class AtlasModelViewSet(viewsets.ModelViewSet, GeneralActionsMixin, ExtraActionsMixin, TargetRouteMixin):


### PR DESCRIPTION
Added url to generate the report url based on the grid_id `http:///localhost:58000/api/grids/GRID_ID_HERE/get_report_url/`. 

Response is a single string:
example: GET request to `http:///localhost:58000/api/grids/1grid_1JEFNic0eYRs4ScE9gYmurdp/get_report_url/`
Response: `"http://localhost:58000/smartscope/browse/?group=15&session_id=20241008hex_testyov2JHNwiFwYJP&grid_id=1grid_1JEFNic0eYRs4ScE9gYmurdp"`